### PR TITLE
Fix docker port

### DIFF
--- a/postgresqldb-docker-compose.yml
+++ b/postgresqldb-docker-compose.yml
@@ -4,7 +4,7 @@ services:
     postgres:
         image: postgres:16.2
         ports:
-            - ${DB_PORT}:${DB_PORT}
+            - ${DB_PORT}:5432
         volumes:
             - db:/var/lib/postgresql/data
         environment:


### PR DESCRIPTION
Postgres is hard coded to use the internal 5432 port, so you need to always use that no matter what you want the external port to be.