### PR TITLE
Send calctime in location streams

### DIFF
--- a/src/CronSetup.ts
+++ b/src/CronSetup.ts
@@ -74,7 +74,8 @@ async function calculateLocations() {
 			});
 		//send data to subscribers => locations
 		newLocations.push({
-			identifier: identifier,
+			identifier,
+			calctime,
 			x: coordinates.x,
 			y: coordinates.y,
 		});

--- a/src/gRPC/GRPCServer.ts
+++ b/src/gRPC/GRPCServer.ts
@@ -197,9 +197,9 @@ export class GRPCServer {
 			} else {
 				locationObject.location.push({
 					identifier: loc.identifier,
+					calctime: loc.calctime,
 					x: loc.x,
 					y: loc.y,
-					calctime: loc.calctime,
 				});
 			}
 		}


### PR DESCRIPTION
`calctime` was not sent when streaming locations, which resulted in all data being invalidated on the client side.